### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Java-BookStoreShoppingCart
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fpluralsight-projects%2FJava-BookStoreShoppingCart&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![image](https://user-images.githubusercontent.com/47092464/98457700-17698f80-21c5-11eb-89cb-7b9955fc5f59.png)
